### PR TITLE
Add compressor plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/compressor/README.md
+++ b/compressor/README.md
@@ -1,0 +1,74 @@
+# Compressor plugin for Allolib
+
+## Overview
+
+This is a compressor plugin designed for plug-and-play use in Allolib sound
+synthesis programs. It operates on `AudioIOData` buffers, which are produced
+and consumed by `SynthGUIManager::render()` and `App::onSound()`, among others.
+It is a wrapper around the
+[SimpleCompressor](https://github.com/DanielRudrich/SimpleCompressor) plugin by
+[Daniel Rudrich](https://github.com/DanielRudrich).
+
+## Usage
+
+This plugin uses a preset-based system for compressor creation. There are just a
+few presets so far:
+- `HARD_CLIP_0DB`: clamp the audio signal to the range [-1, 1], equivalent to
+  what Allolib already does
+- `STRONG_LIMITER_MAX_12DB`: some settings I came up with through
+  experimentation that seem to work well for playing on a keyboard with high
+  amplitudes
+- `SOFT_CLIP`: a limiter with a 3dB knee and a hard limit, like `HARD_CLIP_0DB`
+  but with smoothing and attack/release
+
+To create a compressor, you need the audio buffer size (`BLOCK_SIZE`), which is
+also passed to `app.configureAudio()` as the second argument. You also need the
+sample rate (e.g. 48000 Hz) and whether to use lookahead (`false` since not yet
+supported):
+
+```c++
+filter::CompressorPlugin<BLOCK_SIZE> compressor{
+    filter::HARD_CLIP_0DB<BLOCK_SIZE>,  // Start from HARD_CLIP_0DB preset
+    48000., false                       // 48000 Hz sample rate, no lookahead
+}
+```
+
+You can change the compressor parameters using setter methods in `onInit()`,
+which can be chained together:
+
+```c++
+compressor.setThreshold(-6.f)  // Apply compression at -6dB
+          .setKnee(3.f);       // Ease into compression across 3dB
+```
+
+To apply the compressor, simply call it on the `io` object in `app::onSound()`
+after rendering the synthesizer:
+
+```
+synthManager.render(io);  // Render the synthesizer to the AudioIOData output
+compressor(io);           // Apply the compressor to the output
+```
+
+If you find some compressor settings that work well, feel free to add them to
+the bottom of `compressor.h`! You can use `HARD_CLIP_0DB` as a reference.
+
+The demo program `compressor_demo.cpp` compares a few different compressors
+with a MIDI-capable sine synthesizer at amplitude 0.75. Press MIDI note 107 (G7)
+or the "=" key on a keyboard to cycle between the compressors. The standard
+output shows the maximum amplitude before compression, the maximum change in
+amplitude from the compressor, and the maximum amplitude after compression, all
+in dB relative to an amplitude of 1.
+
+## Future work
+
+This plugin currently does not support lookahead. I'm not sure exactly why the
+lookahead doesn't work, but I think it may have to do with needing to delay the
+input signal. Some other future improvements would be to add more presets for
+useful compressor settings and to convert the signal processing code to Gamma.
+
+## License
+
+This plugin is licensed under the GNU General Public License v3.0. It includes
+[SimpleCompressor](https://github.com/DanielRudrich/SimpleCompressor) plugin by
+[Daniel Rudrich](https://github.com/DanielRudrich), whcih is also licensed under
+the GNU General Public License v3.0.

--- a/compressor/compressor.h
+++ b/compressor/compressor.h
@@ -1,0 +1,915 @@
+#pragma once
+
+#include "al/io/al_AudioIOData.hpp"
+#include <iostream>
+
+namespace al {
+
+namespace filter {
+
+// BEGIN FILE SimpleCompressor/src/GainReductionComputer.h
+
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+#include <limits>
+#include <cmath>
+#include <atomic>
+
+/**
+ This class acts as the side-chain path of a dynamic range compressor. It processes a given side-chain signal and computes the gain reduction samples depending on the parameters threshold, knee, attack-time, release-time, ratio, and make-up gain.
+ */
+class GainReductionComputer
+{
+public:
+    GainReductionComputer();
+    ~GainReductionComputer() {}
+
+    // ======================================================================
+    /**
+     Sets the attack time of the compressor in seconds.
+     */
+    void setAttackTime (const float attackTimeInSeconds);
+
+    /**
+     Sets the release time of the compressorin seconds
+     */
+    void setReleaseTime (const float releaseTimeInSeconds);
+
+    /**
+     Sets the knee-width in decibels.
+     */
+    void setKnee (const float kneeInDecibels);
+    const float getKnee() { return knee; }
+
+    /**
+     Sets the threshold above which the compressor will start to compress the signal.
+     */
+    void setThreshold (const float thresholdInDecibels);
+    const float getThreshold() { return threshold; }
+
+    /**
+     Sets the make-up-gain of the compressor in decibels.
+     */
+    void setMakeUpGain (const float makeUpGainInDecibels);
+    const float getMakeUpGain()  { return makeUpGain; }
+
+    /**
+     Sets the ratio of input-output signal above threshold. Set to 1 for no compression, up to infinity for a brickwall limiter.
+     */
+    void setRatio (const float ratio);
+
+    // ======================================================================
+    /**
+     Computes the static output levels for an array of input levels in decibels. Useful for visualization of the compressor's characteristic. Will contain make-up gain.
+     */
+    void getCharacteristic (float* inputLevelsInDecibels, float* destination, const int numSamples);
+
+    /**
+     Computes the static output levels for a given input level in decibels. Useful for visualization of the compressor's characteristic. Will contain make-up gain.
+     */
+    float getCharacteristicSample (const float inputLevelInDecibels);
+
+    // ======================================================================
+    /**
+     Prepares the compressor with sampleRate and expected blockSize. Make sure you call this before you do any processing!
+     */
+    void prepare (const double sampleRate);
+
+    /**
+     Resets the internal state of the compressor.
+     */
+    void reset() { state = 0.0f; }
+
+    /**
+     Computes the gain reduction for a given side-chain signal. The values will be in decibels and will NOT contain the make-up gain.
+     */
+    void computeGainInDecibelsFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples);
+
+    /**
+     Computes the linear gain including make-up gain for a given side-chain signal. The gain written to the destination can be directly applied to the signals which should be compressed.
+     */
+    void computeLinearGainFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples);
+
+    const float getMaxInputLevelInDecibels() { return maxInputLevel; }
+    const float getMaxGainReductionInDecibels() { return maxGainReduction; }
+
+private:
+    inline const float timeToGain (const float timeInSeconds);
+    inline const float applyCharacteristicToOverShoot (const float overShootInDecibels);
+
+    double sampleRate;
+
+    // parameters
+    float knee, kneeHalf;
+    float threshold;
+    float attackTime;
+    float releaseTime;
+    float slope;
+    float makeUpGain;
+
+    std::atomic<float> maxInputLevel {-std::numeric_limits<float>::infinity()};
+    std::atomic<float> maxGainReduction {0};
+
+    //state variable
+    float state;
+
+    float alphaAttack;
+    float alphaRelease;
+};
+
+// END FILE SimpleCompressor/src/GainReductionComputer.h
+
+
+
+
+
+
+
+
+
+
+
+// BEGIN FILE SimpleCompressor/src/GainReductionComputer.cpp
+
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//#include "GainReductionComputer.h"
+
+GainReductionComputer::GainReductionComputer()
+{
+    sampleRate = 0.0f;
+
+    threshold = -10.0f;
+    knee = 0.0f;
+    kneeHalf = 0.0f;
+    attackTime = 0.01f;
+    releaseTime = 0.15f;
+    setRatio (2); // 2 : 1
+    makeUpGain = 0.0f;
+    reset();
+}
+
+void GainReductionComputer::prepare (const double newSampleRate)
+{
+    sampleRate = newSampleRate;
+
+    alphaAttack = 1.0f - timeToGain (attackTime);
+    alphaRelease = 1.0f - timeToGain (releaseTime);
+}
+
+void GainReductionComputer::setAttackTime (const float attackTimeInSeconds)
+{
+    attackTime = attackTimeInSeconds;
+    alphaAttack = 1.0f - timeToGain (attackTime);
+}
+
+void GainReductionComputer::setReleaseTime (const float releaseTimeInSeconds)
+{
+    releaseTime = releaseTimeInSeconds;
+    alphaRelease = 1.0f - timeToGain (releaseTime);
+}
+
+const float GainReductionComputer::timeToGain (const float timeInSeconds)
+{
+    return std::exp (-1.0f / (static_cast<float> (sampleRate) * timeInSeconds));
+}
+
+void GainReductionComputer::setKnee (const float kneeInDecibels)
+{
+    knee = kneeInDecibels;
+    kneeHalf = knee / 2.0f;
+}
+
+void GainReductionComputer::setThreshold (const float thresholdInDecibels)
+{
+    threshold = thresholdInDecibels;
+}
+
+void GainReductionComputer::setMakeUpGain (const float makeUpGainInDecibels)
+{
+    makeUpGain = makeUpGainInDecibels;
+}
+
+void GainReductionComputer::setRatio (const float ratio)
+{
+    slope = 1.0f / ratio - 1.0f;
+}
+
+
+inline const float GainReductionComputer::applyCharacteristicToOverShoot (const float overShootInDecibels)
+{
+    if (overShootInDecibels <= -kneeHalf)
+        return 0.0f;
+    else if (overShootInDecibels > -kneeHalf && overShootInDecibels <= kneeHalf)
+        return 0.5f * slope * (overShootInDecibels + kneeHalf) * (overShootInDecibels + kneeHalf) / knee;
+    else
+        return slope * overShootInDecibels;
+}
+
+void GainReductionComputer::computeGainInDecibelsFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples)
+{
+    maxInputLevel = -std::numeric_limits<float>::infinity();
+    maxGainReduction = 0.0f;
+
+    for (int i = 0; i < numSamples; ++i)
+    {
+        // convert sample to decibels
+        const float levelInDecibels = 20.0f * std::log10 (std::abs(sideChainSignal[i]));
+        
+        if (levelInDecibels > maxInputLevel)
+            maxInputLevel = levelInDecibels;
+
+        // calculate overshoot and apply knee and ratio
+        const float overShoot = levelInDecibels - threshold;
+        const float gainReduction = applyCharacteristicToOverShoot (overShoot);
+
+        // apply ballistics
+        const float diff = gainReduction - state;
+        if (diff < 0.0f) // wanted gain reduction is below state -> attack phase
+            state += alphaAttack * diff;
+        else // release phase
+            state += alphaRelease * diff;
+
+        // write back gain reduction
+        destination[i] = state;
+
+        if (state < maxGainReduction)
+            maxGainReduction = state;
+    }
+}
+
+void GainReductionComputer::computeLinearGainFromSidechainSignal (const float* sideChainSignal, float* destination, const int numSamples)
+{
+    computeGainInDecibelsFromSidechainSignal (sideChainSignal, destination, numSamples);
+    for (int i = 0; i < numSamples; ++i)
+        destination[i] = std::pow (10.0f, 0.05f * (destination[i] + makeUpGain));
+}
+
+
+void GainReductionComputer::getCharacteristic (float* inputLevelsInDecibels, float* dest, const int numSamples)
+{
+    for (int i = 0; i < numSamples; ++i)
+        dest[i] = getCharacteristicSample (inputLevelsInDecibels[i]);
+}
+
+float GainReductionComputer::getCharacteristicSample (const float inputLevelInDecibels)
+{
+    float overShoot = inputLevelInDecibels - threshold;
+    overShoot = applyCharacteristicToOverShoot (overShoot);
+    return overShoot + inputLevelInDecibels + makeUpGain;
+}
+
+// END FILE SimpleCompressor/src/GainReductionComputer.cpp
+
+
+
+
+
+
+
+
+
+
+
+// BEGIN FILE SimpleCompressor/src/LookAheadGainReduction.h
+
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+#include <vector>
+
+/** This class acts as a delay line for gain-reduction samples, which additionally fades in high gain-reduction values in order to avoid distortion when limiting an audio signal.
+ */
+class LookAheadGainReduction
+{
+public:
+    LookAheadGainReduction() : sampleRate (0.0) {}
+    ~LookAheadGainReduction() {}
+
+    void setDelayTime (float delayTimeInSeconds);
+
+    const int getDelayInSamples() { return delayInSamples; }
+
+    /** Prepares the processor so it can resize the buffers depending on samplerate and the expected buffersize.
+     */
+    void prepare (const double sampleRate, const int blockSize);
+
+    /** Writes gain-reduction samples into the delay-line. Make sure you call process() afterwards, and read the same amount of samples with the readSamples method. Make also sure the pushed samples are decibel values.
+     */
+    void pushSamples (const float* src, const int numSamples);
+
+    /** Processes the data within the delay line, i.e. fades-in high gain-reduction, in order to reduce distortions.
+     */
+    void process();
+
+    /** Reads smoothed gain-reduction samples back to the destination. Make sure you read as many samples as you've pushed before!
+     */
+    void readSamples (float* dest, const int numSamples);
+
+
+private:
+    /** A little helper-function which calulcates how many samples we should process in a first step before we have to wrap around, as our buffer is a ring-buffer.
+     */
+    inline void getProcessPositions (int startIndex, int numSamples, int& blockSize1, int& blockSize2);
+
+    inline void getWritePositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2);
+
+    inline void getReadPositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2);
+
+
+private:
+    //==============================================================================
+    double sampleRate;
+    int blockSize;
+
+    float delay;
+    int delayInSamples = 0;
+    int writePosition = 0;
+    int lastPushedSamples = 0;
+    std::vector<float> buffer;
+};
+
+// END FILE SimpleCompressor/src/LookAheadGainReduction.h
+
+
+
+
+
+
+
+
+
+
+
+// BEGIN FILE SimpleCompressor/src/LookAheadGainReduction.cpp
+
+/*
+ This file is part of the SimpleCompressor project.
+ https://github.com/DanielRudrich/SimpleCompressor
+ Copyright (c) 2019 Daniel Rudrich
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+//#include "LookAheadGainReduction.h"
+#include <cmath>
+#include <algorithm>
+
+void LookAheadGainReduction::setDelayTime (float delayTimeInSeconds)
+{
+    if (delayTimeInSeconds <= 0.0f)
+        delay = 0.0f;
+    else
+        delay = delayTimeInSeconds;
+
+    if (sampleRate != 0.0)
+        prepare (sampleRate, blockSize);
+}
+
+void LookAheadGainReduction::prepare (const double newSampleRate, const int newBlockSize)
+{
+    sampleRate = newSampleRate;
+    blockSize = newBlockSize;
+
+    delayInSamples = static_cast<int> (delay * sampleRate);
+
+    buffer.resize (blockSize + delayInSamples);
+    std::fill (buffer.begin(), buffer.end(), 0.0f);
+    writePosition = 0;
+}
+
+void LookAheadGainReduction::pushSamples (const float* src, const int numSamples)
+{
+    int startIndex, blockSize1, blockSize2;
+
+    // write in delay line
+    getWritePositions (numSamples, startIndex, blockSize1, blockSize2);
+
+    for (int i = 0; i < blockSize1; ++i)
+        buffer[startIndex + i] = src[i];
+
+    if (blockSize2 > 0)
+        for (int i = 0; i < blockSize2; ++i)
+            buffer[i] = src[blockSize1 + i];
+
+    writePosition += numSamples;
+    writePosition = writePosition % buffer.size();
+
+    lastPushedSamples = numSamples;
+}
+
+void LookAheadGainReduction::process()
+{
+    /** The basic idea here is to look for high gain-reduction values in the signal, and apply a fade which starts exactly  `delayInSamples` many samples before that value appears. Depending on the value itself, the slope of the fade will vary.
+
+     Some things to note:
+        - as the samples are gain-reduction values in decibel, we actually look for negative peaks or local minima.
+        - it's easier for us to time-reverse our search, so we start with the last sample
+        - once we find a minimum, we calculate the slope, which will be called `step`
+        - with that slope, we can calculate the next value of our fade-in `nextGainReductionValue`
+        - once a value in the buffer is below our fade-in value, we found a new minimum, which might not be as deep as the previous one, but as it comes in earlier, it needs more attention, so we update our fade-in slope
+        - our buffer is a ring-buffer which makes things a little bit messy
+     */
+
+
+    // As we don't know any samples of the future, yet, we assume we don't have to apply a fade-in right now, and initialize both `nextGainReductionValue` and step (slope of the fade-in) with zero.
+    float nextGainReductionValue = 0.0f;
+    float step = 0.0f;
+
+
+    // Get the position of the last sample in the buffer, which is the sample right before our new write position.
+    int index = writePosition - 1;
+    if (index < 0) // in case it's negative...
+        index += static_cast<int> (buffer.size()); // ... add the buffersize so we wrap around.
+
+    // == FIRST STEP: Process all recently pushed samples.
+
+    // We want to process all `lastPushedSamples` many samples, so let's find out, how many we can process in a first run before we have to wrap around our `index` variable (ring-buffer).
+    int size1, size2;
+    getProcessPositions (index, lastPushedSamples, size1, size2);
+
+    // first run
+    for (int i = 0; i < size1; ++i)
+    {
+        const float smpl = buffer[index];
+
+        if (smpl > nextGainReductionValue) // in case the sample is above our ramp...
+        {
+            buffer[index] = nextGainReductionValue; // ... replace it with the current ramp value
+            nextGainReductionValue += step; // and update the next ramp value
+        }
+        else // otherwise... (new peak)
+        {
+            step = - smpl / delayInSamples; // calculate the new slope
+            nextGainReductionValue = smpl + step; // and also the new ramp value
+        }
+        --index;
+    }
+
+    // second run
+    if (size2 > 0) // in case we have some samples left for the second run
+    {
+        index = static_cast<int> (buffer.size()) - 1; // wrap around: start from the last sample of the buffer
+
+        // exactly the same procedure as before... I guess I could have written that better...
+        for (int i = 0; i < size2; ++i)
+        {
+            const float smpl = buffer[index];
+
+            if (smpl > nextGainReductionValue)
+            {
+                buffer[index] = nextGainReductionValue;
+                nextGainReductionValue += step;
+            }
+            else
+            {
+                step = - smpl / delayInSamples;
+                nextGainReductionValue = smpl + step;
+            }
+            --index;
+        }
+    }
+
+    /*
+     At this point, we have processed all the new gain-reduction values. For this, we actually don't need a delay/lookahead at all.
+     !! However, we are not finished, yet !!
+     What if the first pushed sample has such a high gain-reduction value, that itself needs a fade-in? So we have to apply a gain-ramp even further into the past. And that is exactly the reason why we need lookahead, why we need to buffer our signal for a short amount of time: so we can apply that gain ramp for the first handful of gain-reduction samples.
+     */
+
+    if (index < 0) // it's possible the index is exactly -1
+        index = static_cast<int> (buffer.size()) - 1; // so let's take care of that
+
+    /*
+     This time we only need to check `delayInSamples` many samples.
+     And there's another cool thing!
+        We know that the samples have been processed already, so in case one of the samples is below our ramp value, that's the new minimum, which has been faded-in already! So what we do is hit the break, and call it a day!
+     */
+    getProcessPositions (index, delayInSamples, size1, size2);
+    bool breakWasUsed = false;
+
+    // first run
+    for (int i = 0; i < size1; ++i) // we iterate over the first size1 samples
+    {
+        const float smpl = buffer[index];
+
+        if (smpl > nextGainReductionValue) // in case the sample is above our ramp...
+        {
+            buffer[index] = nextGainReductionValue; // ... replace it with the current ramp value
+            nextGainReductionValue += step; // and update the next ramp value
+        }
+        else // otherwise... JACKPOT! Nothing left to do here!
+        {
+            breakWasUsed = true; // let the guys know we are finished
+            break;
+        }
+        --index;
+    }
+
+    // second run
+    if (! breakWasUsed && size2 > 0) // is there still some work to do?
+    {
+        index = static_cast<int> (buffer.size()) - 1; // wrap around (ring-buffer)
+        for (int i = 0; i < size2; ++i)
+        {
+            const float smpl = buffer[index];
+
+            // same as before
+            if (smpl > nextGainReductionValue) // in case the sample is above our ramp...
+            {
+                buffer[index] = nextGainReductionValue; // ... replace it with the current ramp value
+                nextGainReductionValue += step; // and update the next ramp value
+            }
+            else // otherwise... already processed -> byebye!
+                break;
+            --index;
+        }
+    }
+}
+
+
+void LookAheadGainReduction::readSamples (float* dest, int numSamples)
+{
+    int startIndex, blockSize1, blockSize2;
+
+    // read from delay line
+    getReadPositions (numSamples, startIndex, blockSize1, blockSize2);
+
+    for (int i = 0; i < blockSize1; ++i)
+        dest[i] = buffer[startIndex + i];
+
+    if (blockSize2 > 0)
+        for (int i = 0; i < blockSize2; ++i)
+            dest[blockSize1 + i] = buffer[i];
+}
+
+
+inline void LookAheadGainReduction::getProcessPositions (int startIndex, int numSamples, int& blockSize1, int& blockSize2)
+{
+    if (numSamples <= 0)
+    {
+        blockSize1 = 0;
+        blockSize2 = 0;
+    }
+    else
+    {
+        blockSize1 = std::min (startIndex + 1, numSamples);
+        numSamples -= blockSize1;
+        blockSize2 = numSamples <= 0 ? 0 : numSamples;
+    }
+}
+
+inline void LookAheadGainReduction::getWritePositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2)
+{
+    const int L = static_cast<int> (buffer.size());
+    int pos = writePosition;
+
+    if (pos < 0)
+        pos = pos + L;
+    pos = pos % L;
+
+    if (numSamples <= 0)
+    {
+        startIndex = 0;
+        blockSize1 = 0;
+        blockSize2 = 0;
+    }
+    else
+    {
+        startIndex = pos;
+        blockSize1 = std::min (L - pos, numSamples);
+        numSamples -= blockSize1;
+        blockSize2 = numSamples <= 0 ? 0 : numSamples;
+    }
+}
+
+inline void LookAheadGainReduction::getReadPositions (int numSamples, int& startIndex, int& blockSize1, int& blockSize2)
+{
+    const int L = static_cast<int> (buffer.size());
+    int pos = writePosition - lastPushedSamples - delayInSamples;
+
+    if (pos < 0)
+        pos = pos + L;
+    pos = pos % L;
+
+    if (numSamples <= 0)
+    {
+        startIndex = 0;
+        blockSize1 = 0;
+        blockSize2 = 0;
+    }
+    else
+    {
+        startIndex = pos;
+        blockSize1 = std::min (L - pos, numSamples);
+        numSamples -= blockSize1;
+        blockSize2 = numSamples <= 0 ? 0 : numSamples;
+    }
+}
+
+// END FILE SimpleCompressor/src/LookAheadGainReduction.cpp
+
+
+
+
+
+
+
+
+
+
+
+float linearToDecibels(float linear) {
+  return 20.f * std::log10(std::abs(linear));
+}
+
+float decibelsToLinear(float decibels) {
+  return std::pow(10.f, decibels / 20.f);
+}
+
+
+template <int block_size>
+class CompressorPlugin {
+  private:
+  GainReductionComputer gain;
+  LookAheadGainReduction lookahead;
+
+  float sidechain_buf[block_size];
+  float gain_buf[block_size];
+  float look_buf[block_size];
+
+  double sampleRate;
+  float knee;
+  float threshold;
+  float attackTime;
+  float releaseTime;
+  float ratio;
+  float makeUpGain;
+
+  float debugPrePeak;
+  float debugMaxCompress;
+  float debugPostPeak;
+
+  bool _useLookAhead;
+
+  public:
+  CompressorPlugin(
+      double sampleRateHz, float kneeDb, float thresholdDb,
+      float attackTimeSeconds, float releaseTimeSeconds, float ratioDbDb,
+      float makeUpGainDb, bool useLookAhead
+           ) : 
+      sampleRate(sampleRateHz), knee(kneeDb), threshold(thresholdDb),
+      attackTime(attackTimeSeconds), releaseTime(releaseTimeSeconds),
+      ratio(ratioDbDb), makeUpGain(makeUpGainDb), _useLookAhead(useLookAhead)
+      {
+    gain.prepare       (sampleRate);
+    gain.setKnee       (knee);
+    gain.setThreshold  (threshold);
+    gain.setAttackTime (attackTime);
+    gain.setReleaseTime(releaseTime);
+    gain.setRatio      (ratio);
+    gain.setMakeUpGain (makeUpGain);
+
+    lookahead.prepare(48000., 2 * block_size);
+    lookahead.setDelayTime(0.005f);
+
+    resetDebugStats();
+  }
+
+  CompressorPlugin(
+      const CompressorPlugin& other, double sampleRate,
+      bool useLookAhead) {
+    new (this) CompressorPlugin(
+      sampleRate, other.knee, other.threshold, other.attackTime,
+      other.releaseTime, other.ratio, other.makeUpGain, useLookAhead
+    );
+  }
+
+  CompressorPlugin(const CompressorPlugin& other) = delete;
+
+  //CompressorPlugin(const CompressorPlugin&& other) = delete;
+
+  //CompressorPlugin& operator=(const CompressorPlugin& other) = delete;
+
+  //if I add a typical copy constructor that calls my second constructor, it 
+
+  CompressorPlugin<block_size>& setSampleRate(const double sampleRateHz) {
+    sampleRate = sampleRateHz;
+    gain.prepare(sampleRate);
+    return *this;
+  }
+
+  CompressorPlugin<block_size>& setKnee(const float kneeDb) {
+    knee = kneeDb;
+    gain.setKnee(knee);
+    return *this;
+  }
+
+  CompressorPlugin<block_size>& setThreshold(const float thresholdDb) {
+    threshold = thresholdDb;
+    gain.setThreshold(threshold);
+    return *this;
+  }
+
+  CompressorPlugin<block_size>& setAttackTime(const float attackTimeSeconds) {
+    attackTime = attackTimeSeconds;
+    gain.setAttackTime(attackTime);
+    return *this;
+  }
+
+  CompressorPlugin<block_size>& setReleaseTime(const float releaseTimeSeconds) {
+    releaseTime = releaseTimeSeconds;
+    gain.setReleaseTime(releaseTime);
+    return *this;
+  }
+
+  CompressorPlugin<block_size>& setRatio(const float ratioDbDb) {
+    ratio = ratioDbDb;
+    gain.setRatio(ratio);
+    return *this;
+  }
+
+  CompressorPlugin<block_size>& setMakeUpGain(const float makeUpGainDb) {
+    makeUpGain = makeUpGainDb;
+    gain.setMakeUpGain(makeUpGain);
+    return *this;
+  }
+
+  AudioIOData& operator()(AudioIOData& io) {
+    // TODO get look-ahead working
+    io.frame(0);
+    for (int i = 0; io() && i < block_size; i++) {
+      sidechain_buf[i] = std::max(std::abs(io.out(0)), std::abs(io.out(1)));
+    }
+
+    if (_useLookAhead) {
+      gain.computeGainInDecibelsFromSidechainSignal(sidechain_buf, gain_buf, block_size);
+    } else {
+      gain.computeLinearGainFromSidechainSignal(sidechain_buf, gain_buf, block_size);
+    }
+
+
+    if (_useLookAhead) {
+      lookahead.pushSamples(gain_buf, block_size);
+      lookahead.process();
+      lookahead.readSamples(look_buf, block_size);
+
+      for (int i = 0; i < block_size; i++) {
+        gain_buf[i] = decibelsToLinear(look_buf[i]);
+      }
+    }
+
+
+    debugPrePeak = -std::numeric_limits<float>::infinity();
+    debugMaxCompress = 0;
+    debugPostPeak = -std::numeric_limits<float>::infinity();
+
+    io.frame(0);
+    for (int i = 0; io() && i < block_size; i++) {
+      debugPrePeak = std::max(debugPrePeak, std::abs(io.out(0)));
+      debugPrePeak = std::max(debugPrePeak, std::abs(io.out(1)));
+
+      debugMaxCompress = std::min(debugMaxCompress, gain_buf[i]);
+
+      io.out(0) *= gain_buf[i];
+      io.out(1) *= gain_buf[i];
+
+      debugPostPeak = std::max(debugPostPeak, std::abs(io.out(0)));
+      debugPostPeak = std::max(debugPostPeak, std::abs(io.out(1)));
+    }
+
+    return io;
+  }
+
+  void resetDebugStats() {
+      debugPrePeak = -std::numeric_limits<float>::infinity();
+      debugMaxCompress = 0;
+      debugPostPeak = -std::numeric_limits<float>::infinity();
+  }
+
+  float getDebugPrePeak() {
+      /* Get the peak of the latest audio sample buffer before compression. */
+      return debugPrePeak;
+  }
+
+  float getDebugMaxCompress() {
+      /* Get the largest gain reduction from compression for the latest audio sample buffer. */
+      return debugMaxCompress;
+  }
+
+  float getDebugPostPeak() {
+      /* Get the peak of the latest audio sample buffer after compression. */
+      return debugPostPeak;
+  }
+};
+
+
+// A hard clipper on the output to keep it from exceeding 0dB. This shouldn't
+// have any effect when applied directly to the output since Allolib already
+// clamps the amplitudes. However, it can be used as a basis for various hard
+// clipping filters by adjusting the threshold and make-up gain.
+template<int block_size> const CompressorPlugin<block_size>
+HARD_CLIP_0DB{
+    48000.f,  // sampleRateHz
+    0.f,      // kneeDb
+    0.f,      // thresholdDb
+    0.f,      // attackTimeSeconds
+    0.f,      // releaseTimeSeconds
+    std::numeric_limits<float>::infinity(),  // ratioDbDb
+    0.f,      // makeUpGainDb
+    false     // useLookAhead
+};
+
+// A fairly robust limiter that can handle up to about 12dB over the threshold
+// without noticeable clipping. It works well for playing on a keyboard at high
+// amplitude, but its dynamic range could likely be improved.
+template<int block_size> const CompressorPlugin<block_size>
+STRONG_LIMITER_MAX_12DB{
+    48000.f,
+    20.f,
+    -6.f,
+    0.0025f,
+    0.15f,
+    100.f,
+    0.0f,
+    false
+};
+
+// A limiter with a 3dB knee and a hard limit.
+template<int block_size> const CompressorPlugin<block_size>
+SOFT_CLIP{
+    48000.f,
+    3.f,
+    0.f,
+    0.0025f,
+    0.15f,
+    std::numeric_limits<float>::infinity(),
+    0.0f,
+    false
+};
+
+}  // namespace filter
+
+}  // namespace al

--- a/compressor/compressor_demo.cpp
+++ b/compressor/compressor_demo.cpp
@@ -1,0 +1,277 @@
+#include <cstdio>  // for printing to stdout
+#include <ostream>
+
+#include "al/app/al_App.hpp"
+
+#include "voices/SineEnv.h"
+#include "compressor.h"
+
+// using namespace gam;
+using namespace al;
+
+// This example shows how to use SynthVoice and SynthManagerto create an audio
+// visual synthesizer. In a class that inherits from SynthVoice you will
+// define the synth's voice parameters and the sound and graphic generation
+// processes in the onProcess() functions.
+
+const int BLOCK_SIZE = 128;
+
+
+
+
+
+
+
+
+
+
+
+
+
+class MyApp : public App, public MIDIMessageHandler {
+ public:
+  filter::CompressorPlugin<BLOCK_SIZE> quiet{
+    filter::HARD_CLIP_0DB<BLOCK_SIZE>,
+    48000., false
+  };
+
+  filter::CompressorPlugin<BLOCK_SIZE> limiter{
+      filter::STRONG_LIMITER_MAX_12DB<BLOCK_SIZE>,
+      48000., false
+  };
+
+  filter::CompressorPlugin<BLOCK_SIZE> overdrive{
+    filter::HARD_CLIP_0DB<BLOCK_SIZE>,
+    48000., false
+  };
+
+  filter::CompressorPlugin<BLOCK_SIZE> clipper{
+      filter::SOFT_CLIP<BLOCK_SIZE>,
+      48000., false
+  };
+
+
+  void onInit() override {
+      quiet.setMakeUpGain(-6.f);
+      overdrive.setThreshold(-12.f).setMakeUpGain(-6.f);
+      clipper.setThreshold(-6.f);
+      setupMidi();
+  }
+
+
+  void onSound(AudioIOData& io) override {
+    synthManager.render(io);
+    //limiter(io);
+
+    filter::CompressorPlugin<BLOCK_SIZE>* compressor;
+    std::string compressor_desc;
+
+    // Change the current compressor with = on an ASCII keyboard or G7 on a MIDI keyboard
+    switch (curr_compressor) {
+        case 0:
+          compressor = &quiet;
+          compressor_desc = "Quiet (negative make-up gain)";
+          break;
+        case 1:
+          compressor = &limiter;
+          compressor_desc = "Limiter";
+          break;
+        case 2:
+          compressor = &overdrive;
+          compressor_desc = "Overdrive (hard clipper)";
+          break;
+        case 3: default:
+          compressor = &clipper;
+          compressor_desc = "Soft clipper";
+          break;
+    }
+    (*compressor)(io);
+
+    //*/
+    std::cout << "Compressor: " << compressor_desc << std::endl;
+    std::cout << "Peak before compression: " << compressor->getDebugPrePeak() << std::endl;
+    std::cout << "Max gain reduction: " << compressor->getDebugMaxCompress() << std::endl;
+    std::cout << "Peak after compression: " << compressor->getDebugPostPeak() << std::endl;
+    std::cout << std::endl;
+    //*/
+  }
+
+
+
+
+
+
+
+
+
+
+
+  SynthGUIManager<voice::SineEnv> synthManager{"SineEnv"};
+  RtMidiIn midiIn;
+
+  int curr_compressor = 0;
+
+  // This gets called whenever a MIDI message is received on the port
+  void onMIDIMessage(const MIDIMessage& m) {
+      printf("%s: ", MIDIByte::messageTypeString(m.status()));
+
+      // Here we demonstrate how to parse common channel messages
+      switch (m.type()) {
+      case MIDIByte::NOTE_ON:
+      if (m.noteNumber() == 103) {
+          if (m.velocity() > 0.) {
+              curr_compressor++;
+              curr_compressor &= 3;
+          }
+	  } else if (m.velocity() > 0.) {
+		  synthManager.voice()->setInternalParameterValue(
+		      "frequency", ::pow(2.f, (m.noteNumber() - 69.f) / 12.f) * 440.f);
+		  synthManager.triggerOn(m.noteNumber());
+	  } else {
+              synthManager.triggerOff(m.noteNumber());
+	  }
+          break;
+
+      case MIDIByte::NOTE_OFF:
+          if (m.noteNumber() > 0) {
+              synthManager.triggerOff(m.noteNumber());
+          }
+          break;
+
+      case MIDIByte::PITCH_BEND:
+          printf("Value %f", m.pitchBend());
+          break;
+
+          // Control messages need to be parsed again...
+      case MIDIByte::CONTROL_CHANGE:
+          printf("%s ", MIDIByte::controlNumberString(m.controlNumber()));
+          switch (m.controlNumber()) {
+          case MIDIByte::MODULATION:
+              printf("%f", m.controlValue());
+              break;
+
+          case MIDIByte::EXPRESSION:
+              printf("%f", m.controlValue());
+              break;
+          }
+          break;
+      default:;
+      }
+
+      // If it's a channel message, print out channel number
+      if (m.isChannelMessage()) {
+          printf(" (MIDI chan %u)", m.channel() + 1);
+      }
+
+      printf("\n");
+
+      // Print the raw byte values and time stamp
+      printf("\tBytes = ");
+      for (unsigned i = 0; i < 3; ++i) {
+          printf("%3u ", (int)m.bytes[i]);
+      }
+      printf(", time = %g\n", m.timeStamp());
+  }
+
+  // This function is called right after the window is created
+  // It provides a grphics context to initialize ParameterGUI
+  // It's also a good place to put things that should
+  // happen once at startup.
+  void onCreate() override {
+    navControl().active(false);  // Disable navigation via keyboard, since we
+                                 // will be using keyboard for note triggering
+
+    // Set sampling rate for Gamma objects from app's audio
+    gam::sampleRate(audioIO().framesPerSecond());
+
+    imguiInit();
+
+    // Play example sequence. Comment this line to start from scratch
+    //synthManager.synthSequencer().playSequence("synth1.synthSequence");
+    synthManager.synthRecorder().verbose(true);
+  }
+
+  void onAnimate(double dt) override {
+    // The GUI is prepared here
+    imguiBeginFrame();
+    // Draw a window that contains the synth control panel
+    synthManager.drawSynthControlPanel();
+    imguiEndFrame();
+  }
+
+  // The graphics callback function.
+  void onDraw(Graphics& g) override {
+    g.clear();
+    // Render the synth's graphics
+    synthManager.render(g);
+
+    // GUI is drawn here
+    imguiDraw();
+  }
+
+  // Whenever a key is pressed, this function is called
+  bool onKeyDown(Keyboard const& k) override {
+    if (ParameterGUI::usingKeyboard()) {  // Ignore keys if GUI is using
+                                          // keyboard
+      return true;
+    }
+    if (k.key() == '=') {
+      curr_compressor++;
+      curr_compressor &= 3;
+      return true;
+    }
+    if (k.shift()) {
+      // If shift pressed then keyboard sets preset
+      int presetNumber = asciiToIndex(k.key());
+      synthManager.recallPreset(presetNumber);
+    } else {
+      // Otherwise trigger note for polyphonic synth
+      int midiNote = asciiToMIDI(k.key());
+      if (midiNote > 0) {
+        synthManager.voice()->setInternalParameterValue(
+            "frequency", ::pow(2.f, (midiNote - 69.f) / 12.f) * 432.f);
+        synthManager.triggerOn(midiNote);
+      }
+    }
+    return true;
+  }
+
+  // Whenever a key is released this function is called
+  bool onKeyUp(Keyboard const& k) override {
+    int midiNote = asciiToMIDI(k.key());
+    if (midiNote > 0) {
+      synthManager.triggerOff(midiNote);
+    }
+    return true;
+  }
+
+  void setupMidi() {
+    // Check for connected MIDI devices
+    if (midiIn.getPortCount() > 0) {
+      // Bind ourself to the RtMidiIn object, to have the onMidiMessage()
+      // callback called whenever a MIDI message is received
+      MIDIMessageHandler::bindTo(midiIn);
+
+      // Open the last device found
+      unsigned int port = midiIn.getPortCount() - 1;
+      midiIn.openPort(port);
+      printf("Opened port to %s\n", midiIn.getPortName(port).c_str());
+    }
+    else {
+      printf("Error: No MIDI devices found.\n");
+    }
+  }
+
+  void onExit() override { imguiShutdown(); }
+};
+
+int main() {
+  // Create app instance
+  MyApp app;
+
+  // Set up audio
+  app.configureAudio(48000., BLOCK_SIZE, 2, 0);
+
+  app.start();
+  return 0;
+}


### PR DESCRIPTION
This pull request adds a single-header compressor plugin for Allolib that wraps around [SimpleCompressor](https://github.com/DanielRudrich/SimpleCompressor).  The library, demo code, documentation, and license are all included in the `compressor` folder.  